### PR TITLE
Notion DB 연동 및 조회

### DIFF
--- a/kioku-note/apis/route.js
+++ b/kioku-note/apis/route.js
@@ -1,0 +1,23 @@
+import { Client } from "@notionhq/client";
+
+const notion = new Client({
+  auth: process.env.NOTION_API_KEY,
+});
+
+export async function getNotionData() {
+  const db = await notion.databases.retrieve({
+    database_id: process.env.NOTION_DATABASE_ID,
+  });
+
+  const dataSourceId = db.data_sources[0].id;
+
+  console.log("DATA SOURCE ID:", dataSourceId);
+
+  const response = await notion.dataSources.query({
+    data_source_id: dataSourceId,
+  });
+
+  console.log("NOTION DATA:", response.results);
+
+  return response.results;
+}

--- a/kioku-note/app/words/page.tsx
+++ b/kioku-note/app/words/page.tsx
@@ -1,0 +1,46 @@
+import { getNotionData } from "@/apis/route";
+
+export default async function Page() {
+  const data = await getNotionData();
+
+  const words = data.map((page: any) => {
+    return {
+      word: page.properties["단어"]?.title?.[0]?.plain_text || "",
+      meaning: page.properties["주요뜻"]?.rich_text?.[0]?.plain_text || "",
+      memo: page.properties["메모"]?.rich_text?.[0]?.plain_text || "",
+    };
+  });
+
+  return (
+    <div className="min-h-screen bg-[#f5f5f5] flex justify-center py-20">
+      <div className="w-full max-w-md bg-white rounded-xl shadow-xl px-8 py-10">
+        {/* 타이틀 */}
+        <div className="text-center">
+          <p className="text-[16px] text-[#1a1a1a]">기억 노트</p>
+          <p className="text-[26px] mt-1">記憶ノート</p>
+          <p className="text-[13px] text-[#888888] mt-1">kioku note</p>
+        </div>
+
+        <div className="w-9 h-[1px] bg-[#1a1a1a] mx-auto mt-6 mb-10" />
+
+        {/* 단어 리스트 */}
+        <div className="space-y-6">
+          {words.map((item: any, index: number) => (
+            <div
+              key={index}
+              className="border border-[#e5e5e5] rounded-lg p-5 hover:shadow-md transition"
+            >
+              <p className="text-lg font-medium">{item.word}</p>
+
+              <p className="text-sm text-[#666] mt-2">{item.meaning}</p>
+
+              {item.memo && (
+                <p className="text-xs text-[#999] mt-3">{item.memo}</p>
+              )}
+            </div>
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/kioku-note/package-lock.json
+++ b/kioku-note/package-lock.json
@@ -8,6 +8,7 @@
       "name": "kioku-note",
       "version": "0.1.0",
       "dependencies": {
+        "@notionhq/client": "^5.12.0",
         "next": "16.1.6",
         "react": "19.2.3",
         "react-dom": "19.2.3"
@@ -1224,6 +1225,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=12.4.0"
+      }
+    },
+    "node_modules/@notionhq/client": {
+      "version": "5.12.0",
+      "resolved": "https://registry.npmjs.org/@notionhq/client/-/client-5.12.0.tgz",
+      "integrity": "sha512-yLdw1saMUx4lmwMXOk72QK/N0wuw9x0JuOAuAX+q2Z8IEZzB5di6SEKL6a8eNh5cy3RLKdeXaXJFF4NF2LwXDg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@rtsao/scc": {

--- a/kioku-note/package.json
+++ b/kioku-note/package.json
@@ -9,6 +9,7 @@
     "lint": "eslint"
   },
   "dependencies": {
+    "@notionhq/client": "^5.12.0",
     "next": "16.1.6",
     "react": "19.2.3",
     "react-dom": "19.2.3"


### PR DESCRIPTION
## ✨ 기능
Close #9 
Notion DB 기반 일본어 의성어·의태어 단어장 데이터 연동 및 조회

## 📌 작업 내용

- Daum 단어사전에서 JPT 의성어·의태어 데이터 수집
- Excel → CSV 변환 후 Notion DB import
- Notion API를 활용하여 프로젝트와 데이터 연동
- 단어 데이터를 화면에서 렌더링


## 📷 실행 결과
<img width="1405" height="779" alt="스크린샷 2026-03-13 18 15 23" src="https://github.com/user-attachments/assets/f6f4f466-e960-45a6-b518-aea73233b8c1" />


## ✅ 확인 사항

- [x] Notion DB 데이터 정상 호출
- [x] 화면 렌더링 정상 동작
- [x] DB 수정 시 변경 내용 반영