### PR TITLE
Quiz 상세 페이지 및 진행률 연동 기능 구현

### DIFF
--- a/kioku-note/app/(main)/day/[day]/page.tsx
+++ b/kioku-note/app/(main)/day/[day]/page.tsx
@@ -1,0 +1,37 @@
+import { getNotionData } from "@/apis/route";
+import WordCard from "@/app/components/WordCard";
+
+export default async function Page({
+  params,
+}: {
+  params: Promise<{ day: string }>;
+}) {
+  const { day } = await params;
+  const dayNumber = Number(day);
+
+  const data = await getNotionData();
+
+  const words = data.map((page: any) => ({
+    word: page.properties["단어"]?.title?.[0]?.plain_text || "",
+    meaning: page.properties["주요뜻"]?.rich_text?.[0]?.plain_text || "",
+    memo: page.properties["메모"]?.rich_text?.[0]?.plain_text || "",
+  }));
+
+  const start = (dayNumber - 1) * 10;
+  const end = dayNumber * 10;
+
+  const dayWords = words.slice(start, end);
+
+  return (
+    <div className="space-y-6">
+      {dayWords.map((item, index) => (
+        <WordCard
+          key={index}
+          word={item.word}
+          meaning={item.meaning}
+          memo={item.memo}
+        />
+      ))}
+    </div>
+  );
+}

--- a/kioku-note/app/(main)/day/[day]/page.tsx
+++ b/kioku-note/app/(main)/day/[day]/page.tsx
@@ -1,6 +1,8 @@
 import { getNotionData } from "@/apis/route";
 import WordCard from "@/app/components/WordCard";
 
+import Link from "next/link";
+
 export default async function Page({
   params,
 }: {
@@ -23,7 +25,13 @@ export default async function Page({
   const dayWords = words.slice(start, end);
 
   return (
-    <div className="space-y-6">
+    <div className="space-y-5">
+      <Link href={`/quiz?day=${dayNumber}`}>
+        <button className="w-full py-3 bg-black text-white rounded-md mb-5">
+          퀴즈 시작 : クイズ スタート →
+        </button>
+      </Link>
+
       {dayWords.map((item, index) => (
         <WordCard
           key={index}

--- a/kioku-note/app/(main)/day/[day]/page.tsx
+++ b/kioku-note/app/(main)/day/[day]/page.tsx
@@ -19,14 +19,11 @@ export default async function Page({
     memo: page.properties["메모"]?.rich_text?.[0]?.plain_text || "",
   }));
 
-  const start = (dayNumber - 1) * 10;
-  const end = dayNumber * 10;
-
-  const dayWords = words.slice(start, end);
+  const dayWords = words.slice(0, 10);
 
   return (
     <div className="space-y-5">
-      <Link href={`/quiz?day=${dayNumber}`}>
+      <Link href={`/quiz/${dayNumber}`}>
         <button className="w-full py-3 bg-black text-white rounded-md mb-5">
           퀴즈 시작 : クイズ スタート →
         </button>

--- a/kioku-note/app/(main)/home/page.tsx
+++ b/kioku-note/app/(main)/home/page.tsx
@@ -7,8 +7,8 @@ export default function Page() {
   }));
 
   return (
-    <div className="min-h-screen flex justify-center py-5 bg-[#f5f5f5]">
-      <div className="w-full max-w-md space-y-4">
+    <div className="min-h-screen flex justify-center py-8">
+      <div className="w-full max-w-md flex flex-col space-y-4">
         {days.map((d) => (
           <DayCard key={d.day} day={d.day} progress={d.progress} />
         ))}

--- a/kioku-note/app/(main)/layout.tsx
+++ b/kioku-note/app/(main)/layout.tsx
@@ -7,7 +7,7 @@ export default function MainLayout({
   children: React.ReactNode;
 }) {
   return (
-    <div className="min-h-screen bg-[#f5f5f5] flex justify-center">
+    <div className="min-h-screen flex justify-center">
       <div className="w-full max-w-md min-h-screen bg-white flex flex-col">
         <div className="px-6 pt-10">
           <Title

--- a/kioku-note/app/(main)/quiz/[day]/page.tsx
+++ b/kioku-note/app/(main)/quiz/[day]/page.tsx
@@ -1,7 +1,14 @@
 import { getNotionData } from "@/apis/route";
 import QuizContainer from "@/app/components/QuizContainer";
 
-export default async function QuizPage() {
+export default async function QuizPage({
+  params,
+}: {
+  params: Promise<{ day: string }>;
+}) {
+  const { day } = await params;
+  const dayNumber = Number(day);
+
   const data = await getNotionData();
 
   const words = data.map((page: any) => ({
@@ -9,7 +16,13 @@ export default async function QuizPage() {
     meaning: page.properties["주요뜻"]?.rich_text?.[0]?.plain_text || "",
   }));
 
-  const quizzes = words.slice(0, 10).map((w, _, arr) => {
+  const start = (day - 1) * 10;
+  const end = day * 10;
+
+  console.log("day:", day);
+  console.log("start:", start, "end:", end);
+
+  const quizzes = words.slice(start, end).map((w, _, arr) => {
     const wrong = arr
       .filter((x) => x.meaning !== w.meaning)
       .slice(0, 3)
@@ -26,7 +39,7 @@ export default async function QuizPage() {
 
   return (
     <div className="py-10">
-      <QuizContainer quizzes={quizzes} />
+      <QuizContainer key={day} quizzes={quizzes} day={day} />
     </div>
   );
 }

--- a/kioku-note/app/(main)/words/page.tsx
+++ b/kioku-note/app/(main)/words/page.tsx
@@ -13,7 +13,7 @@ export default async function Page() {
   });
 
   return (
-    <div className="min-h-screen bg-[#f5f5f5] flex justify-center py-5">
+    <div className="min-h-screen flex justify-center py-5">
       {/* 단어 리스트 */}
       <div className="space-y-6">
         {words.map((item: any, index: number) => (

--- a/kioku-note/app/components/DayCard.tsx
+++ b/kioku-note/app/components/DayCard.tsx
@@ -1,13 +1,22 @@
+"use client";
+
 import Link from "next/link";
+import { useEffect, useState } from "react";
 
 type DayCardProps = {
   day: number;
-  progress: number;
 };
 
-export default function DayCard({ day, progress }: DayCardProps) {
+export default function DayCard({ day }: DayCardProps) {
+  const [progress, setProgress] = useState(0);
+
+  useEffect(() => {
+    const saved = JSON.parse(localStorage.getItem("progress") || "{}");
+    setProgress(saved[String(day)] || 0);
+  }, [day]);
+
   return (
-    <Link href={`/day/${day}`}>
+    <Link href={`/day/${day}`} className="block">
       <div className="border border-[#e5e5e5] rounded-lg p-5 hover:shadow-md transition cursor-pointer">
         <p className="text-lg font-semibold">DAY {day}</p>
 

--- a/kioku-note/app/components/DayCard.tsx
+++ b/kioku-note/app/components/DayCard.tsx
@@ -1,24 +1,26 @@
+import Link from "next/link";
+
 type DayCardProps = {
   day: number;
-  progress: number; 
+  progress: number;
 };
 
 export default function DayCard({ day, progress }: DayCardProps) {
   return (
-    <div className="border border-[#e5e5e5] rounded-lg p-5 hover:shadow-md transition cursor-pointer">
+    <Link href={`/day/${day}`}>
+      <div className="border border-[#e5e5e5] rounded-lg p-5 hover:shadow-md transition cursor-pointer">
+        <p className="text-lg font-semibold">DAY {day}</p>
 
-      <p className="text-lg font-semibold">DAY {day}</p>
-
-      {/* 진행률 */}
-      <div className="mt-3">
-        <div className="w-full h-2 bg-[#eee] rounded-full">
-          <div
-            className="h-2 bg-black rounded-full"
-            style={{ width: `${progress}%` }}
-          />
+        <div className="mt-3">
+          <div className="w-full h-2 bg-[#eee] rounded-full">
+            <div
+              className="h-2 bg-black rounded-full"
+              style={{ width: `${progress}%` }}
+            />
+          </div>
+          <p className="text-xs text-[#888] mt-2">{progress}% 완료</p>
         </div>
-        <p className="text-xs text-[#888] mt-2">{progress}% 완료</p>
       </div>
-    </div>
+    </Link>
   );
 }

--- a/kioku-note/app/components/QuizContainer.tsx
+++ b/kioku-note/app/components/QuizContainer.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState, useEffect } from "react";
+import { useRouter } from "next/navigation";
 import QuizCard from "./QuizCard";
 
 type Quiz = {
@@ -16,9 +17,12 @@ export default function QuizContainer({
   quizzes: Quiz[];
   day?: number;
 }) {
+  const router = useRouter();
+
   const [currentIndex, setCurrentIndex] = useState(0);
   const [score, setScore] = useState(0);
   const [answered, setAnswered] = useState(false);
+  const [isFinished, setIsFinished] = useState(false);
 
   const currentQuiz = quizzes[currentIndex];
 
@@ -30,38 +34,46 @@ export default function QuizContainer({
   };
 
   const handleNext = () => {
-    setCurrentIndex((prev) => prev + 1);
-    setAnswered(false);
+    if (currentIndex + 1 >= quizzes.length) {
+      setIsFinished(true);
+    } else {
+      setCurrentIndex((prev) => prev + 1);
+      setAnswered(false);
+    }
   };
 
   useEffect(() => {
-    setCurrentIndex(0);
-    setScore(0);
-    setAnswered(false);
-  }, [day]);
-
-  useEffect(() => {
-    if (!day) return;
-
-    if (currentIndex !== quizzes.length) return;
+    if (!day || !isFinished) return;
 
     const percent = Math.round((score / quizzes.length) * 100);
 
     const saved = JSON.parse(localStorage.getItem("progress") || "{}");
-
     const key = String(day);
-    saved[key] = percent; // ⭐ Math.max 제거 (덮어쓰기)
+
+    saved[key] = percent;
 
     localStorage.setItem("progress", JSON.stringify(saved));
-  }, [currentIndex, day, quizzes.length, score]);
+  }, [isFinished, day, score, quizzes.length]);
 
-  if (currentIndex >= quizzes.length) {
+  if (isFinished) {
+    const percent = Math.round((score / quizzes.length) * 100);
+
     return (
-      <div className="text-center">
-        <p className="text-xl font-semibold">퀴즈 완료 🎉</p>
-        <p className="mt-3">
+      <div className="flex flex-col items-center justify-center mt-20 text-center animate-fadeIn">
+        <p className="text-2xl font-bold mb-4">퀴즈 완료 🎉</p>
+
+        <p className="text-lg">
           점수: {score} / {quizzes.length}
         </p>
+
+        <p className="text-sm text-[#666] mt-2">{percent}% 달성</p>
+
+        <button
+          onClick={() => router.push("/home")}
+          className="mt-6 px-6 py-3 bg-black text-white rounded-md hover:opacity-90 transition"
+        >
+          홈으로 ホームへ →
+        </button>
       </div>
     );
   }

--- a/kioku-note/app/components/QuizContainer.tsx
+++ b/kioku-note/app/components/QuizContainer.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import QuizCard from "./QuizCard";
 
 type Quiz = {
@@ -9,19 +9,51 @@ type Quiz = {
   options: string[];
 };
 
-export default function QuizContainer({ quizzes }: { quizzes: Quiz[] }) {
+export default function QuizContainer({
+  quizzes,
+  day,
+}: {
+  quizzes: Quiz[];
+  day?: number;
+}) {
   const [currentIndex, setCurrentIndex] = useState(0);
   const [score, setScore] = useState(0);
+  const [answered, setAnswered] = useState(false);
 
   const currentQuiz = quizzes[currentIndex];
 
   const handleAnswer = (isCorrect: boolean) => {
+    if (answered) return;
+
+    setAnswered(true);
     if (isCorrect) setScore((prev) => prev + 1);
   };
 
   const handleNext = () => {
     setCurrentIndex((prev) => prev + 1);
+    setAnswered(false);
   };
+
+  useEffect(() => {
+    setCurrentIndex(0);
+    setScore(0);
+    setAnswered(false);
+  }, [day]);
+
+  useEffect(() => {
+    if (!day) return;
+
+    if (currentIndex !== quizzes.length) return;
+
+    const percent = Math.round((score / quizzes.length) * 100);
+
+    const saved = JSON.parse(localStorage.getItem("progress") || "{}");
+
+    const key = String(day);
+    saved[key] = percent; // ⭐ Math.max 제거 (덮어쓰기)
+
+    localStorage.setItem("progress", JSON.stringify(saved));
+  }, [currentIndex, day, quizzes.length, score]);
 
   if (currentIndex >= quizzes.length) {
     return (
@@ -36,6 +68,7 @@ export default function QuizContainer({ quizzes }: { quizzes: Quiz[] }) {
 
   return (
     <div>
+      {/* 진행도 */}
       <p className="text-sm text-[#888] mb-4">
         {currentIndex + 1} / {quizzes.length}
       </p>
@@ -44,7 +77,10 @@ export default function QuizContainer({ quizzes }: { quizzes: Quiz[] }) {
 
       <button
         onClick={handleNext}
-        className="mt-6 w-full py-3 bg-black text-white rounded-md"
+        disabled={!answered}
+        className={`mt-6 w-full py-3 rounded-md ${
+          answered ? "bg-black text-white" : "bg-gray-300"
+        }`}
       >
         다음 문제 →
       </button>

--- a/kioku-note/app/components/Title.tsx
+++ b/kioku-note/app/components/Title.tsx
@@ -13,7 +13,7 @@ export default function Title({ title, subtitle, romanized }: TitleProps) {
         <p className="text-[13px] text-[#888888] mt-1">{romanized}</p>
       )}
 
-      <div className="w-9 h-[1px] bg-[#1a1a1a] mx-auto mt-6 mb-10" />
+      <div className="w-9 h-[1px] bg-[#1a1a1a] mx-auto mt-6 mb-3" />
     </div>
   );
 }

--- a/kioku-note/app/globals.css
+++ b/kioku-note/app/globals.css
@@ -39,3 +39,18 @@ body {
 .animate-fadeIn {
   animation: fadeIn 1.2s ease-in-out;
 }
+
+@keyframes fadeIn {
+  from {
+    opacity: 0;
+    transform: translateY(10px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+.animate-fadeIn {
+  animation: fadeIn 0.4s ease-in-out;
+}

--- a/kioku-note/app/login/page.tsx
+++ b/kioku-note/app/login/page.tsx
@@ -1,6 +1,6 @@
 export default function Page() {
   return (
-    <div className="min-h-screen bg-[#f5f5f5] flex items-center justify-center">
+    <div className="min-h-screen flex items-center justify-center">
       {/* 카드 컨테이너 */}
       <div
         className="


### PR DESCRIPTION
# 📚 Quiz 기능 구현 및 진행률 시스템 추가

## 🧩 주요 기능

### 1. DAY 기반 퀴즈 시스템

* `/quiz/[day]` 동적 라우팅 적용
* DAY별 단어 데이터를 기반으로 퀴즈 생성
* 각 문제는 객관식 4지선다 형태로 구성

### 2. 퀴즈 진행 로직

* 문제 선택 시 정답 여부 판별
* `다음 문제` 버튼을 통해 순차 진행
* 마지막 문제 도달 시 자동 종료 상태 전환

### 3. 결과 화면 및 UX 개선

* 퀴즈 완료 시 결과 화면 표시

  * 총 점수
  * 정답률(%)
* 홈으로 이동하는 버튼 제공 (자동 이동 기능 제거)

### 4. 진행률 저장 (localStorage)

* DAY별 정답률을 localStorage에 저장
* key: `progress`
* 구조:

```json
{
  "1": 40,
  "2": 80
}
```

### 5. 홈 화면 진행률 UI

* DAY 카드에 진행률(progress bar) 표시
* 저장된 값 기반으로 퍼센트 렌더링

### ✅ App Router 동적 라우팅

* `app/(main)/quiz/[day]/page.tsx`
* `params`를 Promise로 받아 `await` 처리 (Next.js 최신 스펙 대응)

### ✅ 상태 관리

* `currentIndex`: 현재 문제 위치
* `score`: 맞춘 개수
* `answered`: 중복 선택 방지
* `isFinished`: 퀴즈 종료 여부


## 🐛 해결한 이슈

### 1. params undefined → NaN 문제

* 원인: 잘못된 라우팅 구조 / params 처리 방식
* 해결:

  * `[day]` 폴더 구조 정리
  * `params`를 Promise로 받아 `await` 처리

### 2. quizzes가 빈 배열 → 0/0 출력 문제

* 원인: `day` 값 NaN → slice 실패
* 해결: params 정상화

### 3. 진행률이 모든 DAY에서 100%로 덮어쓰기 되는 문제

* 원인: useEffect가 매 렌더마다 실행
* 해결:

  * `isFinished` 상태 기반으로 저장 시점 제한

## 🎯 UX 개선 사항

* 퀴즈 완료 후 자동 이동 제거
* 사용자 제어 기반 "홈으로" 버튼 추가

## ✅ Checklist

* [x] DAY별 퀴즈 페이지 구현
* [x] 동적 라우팅 (`/quiz/[day]`)
* [x] 객관식 퀴즈 UI 구현
* [x] 정답 판별 로직 구현
* [x] 다음 문제 이동 기능 구현
* [x] 퀴즈 완료 상태 처리
* [x] 결과 화면 UI 구현
* [x] localStorage 기반 진행률 저장
* [x] DAY 카드 진행률 표시
* [x] 진행률 저장 버그 수정
* [x] params NaN 이슈 해결
* [x] UX 개선 (자동 이동 → 버튼 이동)